### PR TITLE
Change to backgroundable service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"
@@ -13,12 +14,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Quinecamera"
         tools:targetApi="31">
+        <service
+            android:name=".CameraService"
+            android:foregroundServiceType="camera"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/example/quinecamera/CameraService.kt
+++ b/app/src/main/java/com/example/quinecamera/CameraService.kt
@@ -1,0 +1,144 @@
+package com.example.quinecamera
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.ImageFormat
+import android.graphics.Rect
+import android.graphics.YuvImage
+import android.os.Build
+import android.os.IBinder
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.Executors
+
+class CameraService : Service() {
+
+    private val channelId = "CameraServiceChannel"
+    private val notificationId = 1
+
+    private lateinit var mjpegServer: MJpegServer
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    private val serviceLifecycleOwner = ServiceLifecycleOwner()
+
+    override fun onCreate() {
+        super.onCreate()
+        serviceLifecycleOwner.start()
+        createNotificationChannel()
+        val notification = createNotification()
+        startForeground(notificationId, notification)
+
+        mjpegServer = MJpegServer(8080)
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            startCamera()
+        } else {
+            stopSelf()
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_NOT_STICKY
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+
+            val imageAnalysis = ImageAnalysis.Builder()
+                .build()
+                .also {
+                    it.setAnalyzer(Executors.newSingleThreadExecutor(), ImageAnalyzer(mjpegServer))
+                }
+
+            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(serviceLifecycleOwner, cameraSelector, imageAnalysis)
+
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceLifecycleOwner.destroy()
+        mjpegServer.stopServer()
+    }
+
+    private class ImageAnalyzer(private val server: MJpegServer) : ImageAnalysis.Analyzer {
+
+        override fun analyze(image: ImageProxy) {
+            if (image.format != ImageFormat.YUV_420_888) {
+                return
+            }
+
+            val yBuffer = image.planes[0].buffer
+            val uBuffer = image.planes[1].buffer
+            val vBuffer = image.planes[2].buffer
+
+            val ySize = yBuffer.remaining()
+            val uSize = uBuffer.remaining()
+            val vSize = vBuffer.remaining()
+
+            val nv21 = ByteArray(ySize + uSize + vSize)
+            yBuffer.get(nv21, 0, ySize)
+            vBuffer.get(nv21, ySize, vSize)
+            uBuffer.get(nv21, ySize + vSize, uSize)
+
+            val yuvImage = YuvImage(nv21, ImageFormat.NV21, image.width, image.height, null)
+            val outputStream = ByteArrayOutputStream()
+
+            yuvImage.compressToJpeg(Rect(0, 0, image.width, image.height), 90, outputStream)
+            val jpegData = outputStream.toByteArray()
+
+            server.updateJpeg(jpegData)
+
+            outputStream.close()
+            image.close()
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "Camera Service"
+            val descriptionText = "Streams the phone camera to an HTTP endpoint."
+            val importance = NotificationManager.IMPORTANCE_LOW
+            val channel = NotificationChannel(channelId, name, importance).apply {
+                description = descriptionText
+            }
+            val notificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun createNotification(): Notification {
+        val builder = NotificationCompat.Builder(this, channelId)
+//            .setSmallIcon(R.drawable.ic_notification) // Replace with your app's icon
+            .setContentTitle("Camera Service")
+            .setContentText("Streaming phone camera to an HTTP endpoint.")
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+        return builder.build()
+    }
+
+
+}

--- a/app/src/main/java/com/example/quinecamera/MJpegServer.kt
+++ b/app/src/main/java/com/example/quinecamera/MJpegServer.kt
@@ -3,7 +3,6 @@ package com.example.quinecamera
 import android.util.Log
 import fi.iki.elonen.NanoHTTPD
 import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.util.concurrent.atomic.AtomicReference
 
 class MJpegServer(port: Int) : NanoHTTPD(port) {

--- a/app/src/main/java/com/example/quinecamera/MainActivity.kt
+++ b/app/src/main/java/com/example/quinecamera/MainActivity.kt
@@ -4,9 +4,11 @@ import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.CameraSelector
 import androidx.core.content.ContextCompat
 import com.example.quinecamera.databinding.ActivityMainBinding
 
@@ -15,7 +17,9 @@ class MainActivity : AppCompatActivity() {
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
-                startCameraService()
+                val portNumber = binding.portNumberEditText.text.toString().toIntOrNull() ?: 8080
+                val cameraSelector = if (binding.cameraToggle.isChecked) "FRONT" else "BACK"
+                startCameraService(portNumber, cameraSelector)
             } else {
                 Toast.makeText(this, "Permission denied", Toast.LENGTH_SHORT).show()
                 finish()
@@ -29,19 +33,44 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        val portNumberEditText = binding.portNumberEditText
+        val cameraToggle = binding.cameraToggle
+
         if (ContextCompat.checkSelfPermission(
                 this,
                 Manifest.permission.CAMERA
             ) == PackageManager.PERMISSION_GRANTED
         ) {
-            startCameraService()
+            val portNumber = portNumberEditText.text.toString().toIntOrNull() ?: 8080
+            val cameraSelector = if (cameraToggle.isChecked) "FRONT" else "BACK"
+            startCameraService(portNumber, cameraSelector)
         } else {
             requestPermissionLauncher.launch(Manifest.permission.CAMERA)
         }
+
+        cameraToggle.setOnCheckedChangeListener { _, isChecked ->
+            val portNumber = portNumberEditText.text.toString().toIntOrNull() ?: 8080
+            val cameraSelector = if (isChecked) "FRONT" else "BACK"
+            startCameraService(portNumber, cameraSelector)
+        }
+
+        portNumberEditText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                val portNumber = portNumberEditText.text.toString().toIntOrNull() ?: 8080
+                val cameraSelector = if (cameraToggle.isChecked) "FRONT" else "BACK"
+                startCameraService(portNumber, cameraSelector)
+                true
+            } else {
+                false
+            }
+        }
     }
 
-    private fun startCameraService() {
+
+    private fun startCameraService(portNumber: Int, cameraSelector: String) {
         val serviceIntent = Intent(this, CameraService::class.java)
+        serviceIntent.putExtra("portNumber", portNumber)
+        serviceIntent.putExtra("cameraSelector", cameraSelector)
         ContextCompat.startForegroundService(this, serviceIntent)
     }
 }

--- a/app/src/main/java/com/example/quinecamera/MainActivity.kt
+++ b/app/src/main/java/com/example/quinecamera/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.quinecamera
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.ImageFormat
 import android.graphics.Rect
@@ -25,14 +26,13 @@ class MainActivity : AppCompatActivity() {
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
-                startCamera()
+                startCameraService()
             } else {
                 Toast.makeText(this, "Permission denied", Toast.LENGTH_SHORT).show()
                 finish()
             }
         }
 
-    private lateinit var mjpegServer: MJpegServer
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,81 +40,19 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        mjpegServer = MJpegServer(8080)
-
         if (ContextCompat.checkSelfPermission(
                 this,
                 Manifest.permission.CAMERA
             ) == PackageManager.PERMISSION_GRANTED
         ) {
-            startCamera()
+            startCameraService()
         } else {
             requestPermissionLauncher.launch(Manifest.permission.CAMERA)
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        mjpegServer.stopServer()
-    }
-
-    private fun startCamera() {
-        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
-
-        cameraProviderFuture.addListener({
-            val cameraProvider = cameraProviderFuture.get()
-
-            val preview = Preview.Builder()
-                .build()
-
-            // Use setSurfaceProvider() on the Preview object
-            preview.setSurfaceProvider(binding.viewFinder.surfaceProvider)
-
-            val imageAnalysis = ImageAnalysis.Builder()
-                .build()
-                .also {
-                    it.setAnalyzer(Executors.newSingleThreadExecutor(), ImageAnalyzer(mjpegServer))
-                }
-
-            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-
-            cameraProvider.unbindAll()
-            cameraProvider.bindToLifecycle(this, cameraSelector, preview, imageAnalysis)
-
-        }, ContextCompat.getMainExecutor(this))
-    }
-
-
-    private class ImageAnalyzer(private val server: MJpegServer) : ImageAnalysis.Analyzer {
-
-        override fun analyze(image: ImageProxy) {
-            if (image.format != ImageFormat.YUV_420_888) {
-                return
-            }
-
-            val yBuffer = image.planes[0].buffer
-            val uBuffer = image.planes[1].buffer
-            val vBuffer = image.planes[2].buffer
-
-            val ySize = yBuffer.remaining()
-            val uSize = uBuffer.remaining()
-            val vSize = vBuffer.remaining()
-
-            val nv21 = ByteArray(ySize + uSize + vSize)
-            yBuffer.get(nv21, 0, ySize)
-            vBuffer.get(nv21, ySize, vSize)
-            uBuffer.get(nv21, ySize + vSize, uSize)
-
-            val yuvImage = YuvImage(nv21, ImageFormat.NV21, image.width, image.height, null)
-            val outputStream = ByteArrayOutputStream()
-
-            yuvImage.compressToJpeg(Rect(0, 0, image.width, image.height), 90, outputStream)
-            val jpegData = outputStream.toByteArray()
-
-            server.updateJpeg(jpegData)
-
-            outputStream.close()
-            image.close()
-        }
+    private fun startCameraService() {
+        val serviceIntent = Intent(this, CameraService::class.java)
+        ContextCompat.startForegroundService(this, serviceIntent)
     }
 }

--- a/app/src/main/java/com/example/quinecamera/MainActivity.kt
+++ b/app/src/main/java/com/example/quinecamera/MainActivity.kt
@@ -3,23 +3,12 @@ package com.example.quinecamera
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.ImageFormat
-import android.graphics.Rect
-import android.graphics.YuvImage
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.core.Preview
-import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.content.ContextCompat
 import com.example.quinecamera.databinding.ActivityMainBinding
-import java.io.ByteArrayOutputStream
-
-import java.util.concurrent.Executors
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/example/quinecamera/ServiceLifecycleOwner.kt
+++ b/app/src/main/java/com/example/quinecamera/ServiceLifecycleOwner.kt
@@ -1,0 +1,34 @@
+package com.example.quinecamera
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+class ServiceLifecycleOwner : LifecycleOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+
+    init {
+        lifecycleRegistry.currentState = Lifecycle.State.CREATED
+    }
+
+    override fun getLifecycle(): Lifecycle {
+        return lifecycleRegistry
+    }
+
+    fun start() {
+        lifecycleRegistry.currentState = Lifecycle.State.STARTED
+    }
+
+    fun stop() {
+        lifecycleRegistry.currentState = Lifecycle.State.CREATED
+    }
+
+    fun destroy() {
+        lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+    }
+}
+
+
+
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,26 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <androidx.camera.view.PreviewView
-        android:id="@+id/viewFinder"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    <EditText
+        android:id="@+id/portNumberEditText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        android:hint="Port (Default: 8080)"
+        android:layout_gravity="center_horizontal"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ToggleButton
+        android:id="@+id/cameraToggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textOn="Front Camera"
+        android:textOff="Back Camera"
+        app:layout_constraintTop_toBottomOf="@+id/portNumberEditText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR changes the app to a background service, so the camera keeps streaming when the camera app is closed. It also allows one to:
1. configure the server port (default: 8080) 
2. select which camera to stream, either front or back. 

It also removes the camera preview in the MainActivity for now as couldn't seem to get that to work and wasn't super useful.